### PR TITLE
VAR-4: Remove variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.0] - 2023-01-17
+## [0.15.0] - 2023-01-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2023-01-17
+
+### Added
+
+- Added feature to remove a variable.
+
 ## [0.14.0] - 2023-01-16
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.14.0</version>
+    <version>0.15.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.14.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.15.0");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/variable/application/Variable.java
+++ b/src/main/java/variable/application/Variable.java
@@ -82,6 +82,15 @@ public class Variable {
     }
 
     /**
+     * Update the deletion state for the variable.
+     *
+     * @param isDeleted Whether the variable is deleted from the system or not.
+     */
+    public void setIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    /**
      * Create a variable given its attribute values.
      *
      * @param attributes Map containing the value for each variable attribute.

--- a/src/main/java/variable/application/usecases/RemoveVariable.java
+++ b/src/main/java/variable/application/usecases/RemoveVariable.java
@@ -1,0 +1,42 @@
+package variable.application.usecases;
+
+import variable.application.Variable;
+import variable.persistence.VariableRepository;
+
+/**
+ * Remove variable use case.
+ */
+public class RemoveVariable {
+
+    /**
+     * @see VariableRepository
+     */
+    private VariableRepository variableRepository;
+
+    /**
+     * Constructor.
+     *
+     * @param variableRepository Variable repository.
+     */
+    public RemoveVariable(VariableRepository variableRepository) {
+        this.variableRepository = variableRepository;
+    }
+
+    /**
+     * Remove the variable which matches with the given name.
+     *
+     * @param name The name of the variable to remove.
+     * @return Whether the variable has been removed or not.
+     */
+    public boolean execute(String name) {
+        Variable variable = variableRepository.find(name);
+
+        if (variable == null) {
+            return false;
+        }
+
+        variable.setIsDeleted(true);
+        return variableRepository.update(variable);
+    }
+
+}

--- a/src/main/java/variable/persistence/VariableRepository.java
+++ b/src/main/java/variable/persistence/VariableRepository.java
@@ -39,4 +39,12 @@ public interface VariableRepository extends Repository {
      */
     public boolean update(Variable variable);
 
+    /**
+     * Find the variable which matches with the given name.
+     *
+     * @param name The name of the variable to find.
+     * @return The found variable, otherwise null.
+     */
+    public Variable find(String name);
+
 }

--- a/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
+++ b/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
@@ -131,6 +131,22 @@ public class MongoVariableRepository extends MongoRepository implements Variable
      * {@inheritDoc}
      */
     @Override
+    public Variable find(String name) {
+        Bson variableNameFilter = this.getVariableNameFilter(name);
+        ArrayList<Document> foundVariableDocuments = super.find(variableNameFilter);
+
+        if (foundVariableDocuments.isEmpty()) {
+            return null;
+        } else {
+            Document foundVariableDocument = foundVariableDocuments.get(0);
+            return this.createVariableFrom(foundVariableDocument);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public ArrayList<Variable> get() {
         ArrayList<Document> foundDocuments = super.find();
 

--- a/src/main/java/variable/presentation/panels/ListVariablesPanel.java
+++ b/src/main/java/variable/presentation/panels/ListVariablesPanel.java
@@ -19,6 +19,7 @@ import variable.application.SubtotalVariable;
 import variable.application.Variable;
 import variable.application.usecases.ListVariables;
 import variable.persistence.mongo.MongoVariableRepository;
+import variable.presentation.utils.ListVariablesMouseAdapter;
 import variable.presentation.utils.ListVariablesTableModel;
 
 /**
@@ -145,6 +146,8 @@ public class ListVariablesPanel extends javax.swing.JPanel {
             Vector<Vector<Object>> data = this.setTableData(variables);
 
             table.setModel(new ListVariablesTableModel(data, columnNames));
+
+            table.addMouseListener(new ListVariablesMouseAdapter(table));
 
             // Set a combobox cell editor for the entity attribute and subtotal columns.
             TableColumn entityAttributeColumn = table.getColumn(columnNames.get(2));

--- a/src/main/java/variable/presentation/utils/ListVariablesMouseAdapter.java
+++ b/src/main/java/variable/presentation/utils/ListVariablesMouseAdapter.java
@@ -1,0 +1,99 @@
+package variable.presentation.utils;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.JTable;
+import javax.swing.table.TableModel;
+import shared.persistence.exceptions.NotDefinedDatabaseContextException;
+import shared.presentation.localization.Localization;
+import shared.presentation.localization.LocalizationKey;
+import variable.application.usecases.RemoveVariable;
+import variable.persistence.mongo.MongoVariableRepository;
+
+/**
+ * Mouse adapter for the list variables panel, which includes a button to remove
+ * or restore a variable.
+ */
+public class ListVariablesMouseAdapter extends MouseAdapter {
+
+    /**
+     * Table associated to the mouse adapter.
+     */
+    private JTable table;
+
+    /**
+     * Constructor.
+     *
+     * @param table The table associated to the mouse adapter.
+     */
+    public ListVariablesMouseAdapter(JTable table) {
+        this.table = table;
+    }
+
+    /**
+     * Execute the remove variable use case.
+     *
+     * @param name The name of the variable to remove.
+     * @return Whether the variable with the given code has been removed or not.
+     */
+    private boolean removeVariable(String name) {
+        try {
+            MongoVariableRepository variableRepository = new MongoVariableRepository();
+            RemoveVariable removeVariable = new RemoveVariable(variableRepository);
+            return removeVariable.execute(name);
+        } catch (NotDefinedDatabaseContextException ex) {
+            String className = ListVariablesMouseAdapter.class.getName();
+            Logger.getLogger(className).log(Level.INFO, "Variable not removed because the database has not been found", ex);
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove or restore the variable depending on the deletion state.
+     *
+     * @param evt The mouse event.
+     */
+    private void removeOrRestoreVariable(MouseEvent evt) {
+        int removeRestoreColumn = 4;
+        int row = table.rowAtPoint(evt.getPoint());
+
+        TableModel tableModel = table.getModel();
+
+        String cellText = (String) tableModel.getValueAt(row, removeRestoreColumn);
+        String removeText = Localization.getLocalization(LocalizationKey.REMOVE);
+        String restoreText = Localization.getLocalization(LocalizationKey.RESTORE);
+
+        String variableName = (String) table.getValueAt(row, 0);
+        String finalVariableName = variableName.substring(2, variableName.length() - 1);
+
+        if (cellText.equals(removeText)) {
+            boolean isVariableRemoved = this.removeVariable(finalVariableName);
+
+            if (isVariableRemoved) {
+                // Button state needs to be updated as the variable state has changed.
+                tableModel.setValueAt(restoreText, row, removeRestoreColumn);
+            }
+        } else {
+            // Button state needs to be updated as the variable state has changed.
+            tableModel.setValueAt(removeText, row, removeRestoreColumn);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void mouseClicked(MouseEvent evt) {
+        int column = table.columnAtPoint(evt.getPoint());
+
+        if (column == 4) {
+            // In column 4, there is a button to restore or remove
+            // the chosen variable defined by the clicked row.
+            this.removeOrRestoreVariable(evt);
+        }
+    }
+
+}

--- a/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
+++ b/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
@@ -161,6 +161,10 @@ public class ListVariablesTableModel extends DefaultTableModel {
         }
 
         super.setValueAt(newValue, row, column);
-        this.editVariable(newValue, row, column);
+
+        // Only update the variable if the cell is editable.
+        if (this.isCellEditable(row, column)) {
+            this.editVariable(newValue, row, column);
+        }
     }
 }


### PR DESCRIPTION
In this PR, I have:

- Established the remove variable use case.
- Added a method to the variable entity class to update the deletion state.
- Fixed an error on the list variables table model where we could edit the variable on non-editable cells.
- Included a method on the variable repository interface to find a variable by its name.
- Implemented that method on the Mongo variable repository.
- Added a mouse listener to the list variables panel to detect when the remove/restore button is clicked for which variable row.