### PR TITLE
BUG-2: Removed variables can be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2023-01-18
+
+### Fixed
+
+- Fixed an issue where a removed variable could be edited.
+
 ## [0.15.0] - 2023-01-18
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.15.0</version>
+    <version>0.15.1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.15.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.15.1");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
+++ b/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
@@ -129,6 +129,7 @@ public class ListVariablesTableModel extends DefaultTableModel {
         // Rows associated to removed variables will not be editable.
         String removeRestoreButtonText = (String) super.getValueAt(row, 4);
         String restoreText = Localization.getLocalization(LocalizationKey.RESTORE);
+        // Restore text is shown when the variable has been removed.
         boolean isVariableRemoved = removeRestoreButtonText.equals(restoreText);
         if (isVariableRemoved) {
             return false;

--- a/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
+++ b/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
@@ -8,6 +8,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.table.DefaultTableModel;
 import shared.persistence.exceptions.NotDefinedDatabaseContextException;
+import shared.presentation.localization.Localization;
+import shared.presentation.localization.LocalizationKey;
 import subtotal.application.Subtotal;
 import subtotal.application.usecases.ListSubtotals;
 import subtotal.persistence.mongo.MongoSubtotalRepository;
@@ -124,6 +126,14 @@ public class ListVariablesTableModel extends DefaultTableModel {
      */
     @Override
     public boolean isCellEditable(int row, int column) {
+        // Rows associated to removed variables will not be editable.
+        String removeRestoreButtonText = (String) super.getValueAt(row, 4);
+        String restoreText = Localization.getLocalization(LocalizationKey.RESTORE);
+        boolean isVariableRemoved = removeRestoreButtonText.equals(restoreText);
+        if (isVariableRemoved) {
+            return false;
+        }
+
         // Subtotal column will not be edited if the entity attribute is not
         // invoice subtotal.
         if (column == 3) {


### PR DESCRIPTION
In this PR, I have fixed the issue by indicating that rows associated with removed variables cannot be edited.