### PR TITLE
SUBT-4: Remove subtotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2023-01-20
+
+### Added
+
+- Added feature to remove a subtotal.
+
 ## [0.16.0] - 2023-01-18
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.16.0</version>
+    <version>0.17.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/persistence/mongo/MongoRepository.java
+++ b/src/main/java/shared/persistence/mongo/MongoRepository.java
@@ -43,6 +43,17 @@ public abstract class MongoRepository {
     }
 
     /**
+     * Count all the documents on the collection which match with the given
+     * filters.
+     *
+     * @param filters The filters.
+     * @return The number of documents on the collection which match the filters.
+     */
+    protected int count(Bson filters) {
+        return (int) this.collection.countDocuments(filters);
+    }
+
+    /**
      * Create a list with the different values that the given field has based on
      * the received filters.
      *

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.16.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.0");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
+++ b/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
@@ -75,6 +75,7 @@ public class SpanishDictionary extends Dictionary {
         super.setTranslation(LocalizationKey.INVOICE_SUBTOTAL, "Subtotal de la factura");
         super.setTranslation(LocalizationKey.INVOICE_TOTAL, "Total de la factura");
         super.setTranslation(LocalizationKey.VARIABLES, "Variables");
+        super.setTranslation(LocalizationKey.SUBTOTAL_ASSOCIATED_WITH_VARIABLE_MESSAGE, "El subtotal no se puede eliminar porque está asociado a una variable");
     }
 
 }

--- a/src/main/java/shared/presentation/localization/LocalizationKey.java
+++ b/src/main/java/shared/presentation/localization/LocalizationKey.java
@@ -256,4 +256,8 @@ public enum LocalizationKey {
      * Variables.
      */
     VARIABLES,
+    /**
+     * Message shown when the subtotal is associated to a variable.
+     */
+    SUBTOTAL_ASSOCIATED_WITH_VARIABLE_MESSAGE,
 }

--- a/src/main/java/subtotal/application/Subtotal.java
+++ b/src/main/java/subtotal/application/Subtotal.java
@@ -98,6 +98,15 @@ public class Subtotal {
     }
 
     /**
+     * Update the deletion state for the subtotal.
+     *
+     * @param isDeleted Whether the subtotal is deleted from the system or not.
+     */
+    public void setIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    /**
      * Set the subtotal percentage.
      *
      * @param percentage A percentage between 0 and 100.

--- a/src/main/java/subtotal/application/usecases/RemoveSubtotal.java
+++ b/src/main/java/subtotal/application/usecases/RemoveSubtotal.java
@@ -1,0 +1,74 @@
+package subtotal.application.usecases;
+
+import subtotal.application.Subtotal;
+import subtotal.application.utils.SubtotalRemovalState;
+import subtotal.persistence.SubtotalRepository;
+import variable.persistence.VariableRepository;
+
+/**
+ * Remove variable use case.
+ */
+public class RemoveSubtotal {
+
+    /**
+     * @see SubtotalRepository
+     */
+    private SubtotalRepository subtotalRepository;
+
+    /**
+     * @see VariableRepository
+     */
+    private VariableRepository variableRepository;
+
+    /**
+     * Constructor.
+     *
+     * @param subtotalRepository Subtotal repository.
+     * @param variableRepository Variable repository.
+     */
+    public RemoveSubtotal(SubtotalRepository subtotalRepository, VariableRepository variableRepository) {
+        this.subtotalRepository = subtotalRepository;
+        this.variableRepository = variableRepository;
+    }
+
+    /**
+     * Check if the subtotal can be removed.
+     *
+     * That can be done if the subtotal is not associated with a variable.
+     *
+     * @param code The subtotal code.
+     * @return Whether the subtotal can be removed or not.
+     */
+    public boolean canBeRemoved(int code) {
+        return !variableRepository.existVariableWithSubtotal(code);
+    }
+
+    /**
+     * Remove the subtotal which matches with the given code.
+     *
+     * @param code The code of the subtotal to remove.
+     * @return The subtotal removal state.
+     */
+    public SubtotalRemovalState execute(int code) {
+        if (!this.canBeRemoved(code)) {
+            return SubtotalRemovalState.ASSOCIATED_WITH_VARIABLE;
+        }
+
+        Subtotal subtotal = subtotalRepository.find(code);
+
+        if (subtotal == null) {
+            return SubtotalRemovalState.NOT_FOUND;
+        }
+
+        subtotal.setIsDeleted(true);
+
+        boolean isSubtotalUpdated = subtotalRepository.update(subtotal);
+
+        if (isSubtotalUpdated) {
+            return SubtotalRemovalState.REMOVED;
+        }
+
+        return SubtotalRemovalState.NOT_UPDATED;
+    }
+
+}

--- a/src/main/java/subtotal/application/utils/SubtotalRemovalState.java
+++ b/src/main/java/subtotal/application/utils/SubtotalRemovalState.java
@@ -1,0 +1,25 @@
+package subtotal.application.utils;
+
+/**
+ * Represents all the states which the subtotal can be after trying to remove
+ * it.
+ */
+public enum SubtotalRemovalState {
+    /**
+     * The subtotal has been removed successfully.
+     */
+    REMOVED,
+    /**
+     * The subtotal cannot be removed because it is associated with at least one
+     * variable.
+     */
+    ASSOCIATED_WITH_VARIABLE,
+    /**
+     * The subtotal cannot be removed because it has not been updated.
+     */
+    NOT_UPDATED,
+    /**
+     * The subtotal cannot be removed because it has not been found.
+     */
+    NOT_FOUND
+}

--- a/src/main/java/subtotal/presentation/utils/ListSubtotalsTableModel.java
+++ b/src/main/java/subtotal/presentation/utils/ListSubtotalsTableModel.java
@@ -140,7 +140,9 @@ public class ListSubtotalsTableModel extends DefaultTableModel {
             super.setValueAt(newValue, row, column);
         }
 
-        this.editSubtotal(newValue, row, column);
+        if (this.isCellEditable(row, column)) {
+            this.editSubtotal(newValue, row, column);
+        }
     }
 
 }

--- a/src/main/java/variable/persistence/VariableRepository.java
+++ b/src/main/java/variable/persistence/VariableRepository.java
@@ -47,4 +47,13 @@ public interface VariableRepository extends Repository {
      */
     public Variable find(String name);
 
+    /**
+     * Checks if there is at least one variable which contains a subtotal with
+     * the given code.
+     *
+     * @param code The subtotal code.
+     * @return Whether a subtotal is associated to at least one variable.
+     */
+    public boolean existVariableWithSubtotal(int code);
+
 }

--- a/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
+++ b/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
@@ -184,4 +184,13 @@ public class MongoVariableRepository extends MongoRepository implements Variable
         return super.replaceOne(variableNameFilter, this.createDocumentFrom(variable));
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean existVariableWithSubtotal(int code) {
+        Bson subtotalFilter = Filters.eq("subtotal", code);
+        return super.count(subtotalFilter) > 0;
+    }
+
 }


### PR DESCRIPTION
In this PR, I have:

- Added the remove subtotal use case.
- Updated the subtotal entity to set a method to modify the deletion state.
- Added an enumeration to indicate the different states after removing a subtotal.
- Implemented a method on the Mongo repository to count documents on a collection based on the given filters.
- Added a method on the variable repository interface to check if there is a variable associated to the given subtotal code.
- Implemented the mentioned method on the Mongo variable repository.
- Update the list subtotals mouse adapter to remove a subtotal when clicked on the remove/restore button of the corresponding subtotal row.
- Show a message on the panel when the subtotal cannot be removed because it is associated to at least one variable.
- Fixed an error on the list subtotals table model where the subtotal is only edited when the cell is editable.