### PR TITLE
BUG-3: You can select a removed subtotal to associate it to a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2023-01-20
+
+### Fixed
+
+- Fixed an issue where a removed subtotal could be associated to a variable.
+
 ## [0.17.0] - 2023-01-20
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.1");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/variable/presentation/panels/ListVariablesPanel.java
+++ b/src/main/java/variable/presentation/panels/ListVariablesPanel.java
@@ -154,8 +154,15 @@ public class ListVariablesPanel extends javax.swing.JPanel {
             JComboBox comboBox = new JComboBox(EntityAttribute.values());
             entityAttributeColumn.setCellEditor(new DefaultCellEditor(comboBox));
 
+            Vector<Subtotal> nonRemovedSubtotals = new Vector<>();
+            for (Subtotal subtotal : this.getSubtotals()) {
+                if (!subtotal.isDeleted()) {
+                    nonRemovedSubtotals.add(subtotal);
+                }
+            }
+
             TableColumn subtotalColumn = table.getColumn(columnNames.get(3));
-            comboBox = new JComboBox(new Vector<Subtotal>(this.getSubtotals()));
+            comboBox = new JComboBox(new Vector<Subtotal>(nonRemovedSubtotals));
             subtotalColumn.setCellEditor(new DefaultCellEditor(comboBox));
 
             // Set a button renderer for the action button.

--- a/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
+++ b/src/main/java/variable/presentation/utils/ListVariablesTableModel.java
@@ -165,9 +165,21 @@ public class ListVariablesTableModel extends DefaultTableModel {
             } else if (newEntityAttribute == EntityAttribute.INVOICE_SUBTOTAL && oldEntityAttribute != EntityAttribute.INVOICE_SUBTOTAL) {
                 // Set the first subtotal by default when choosing the invoice
                 // subtotal entity attribute.
-                ArrayList<Subtotal> subtotals = this.getSubtotals();
-                Subtotal firstSubtotal = subtotals.isEmpty() ? null : subtotals.get(0);
-                super.setValueAt(firstSubtotal, row, 3);
+                Vector<Subtotal> nonRemovedSubtotals = new Vector<>();
+
+                for (Subtotal subtotal : this.getSubtotals()) {
+                    if (!subtotal.isDeleted()) {
+                        nonRemovedSubtotals.add(subtotal);
+                    }
+                }
+
+                if (nonRemovedSubtotals.isEmpty()) {
+                    // Abort the process if there is no subtotal to associate.
+                    return;
+                } else {
+                    Subtotal firstSubtotal = nonRemovedSubtotals.get(0);
+                    super.setValueAt(firstSubtotal, row, 3);
+                }
             }
         }
 


### PR DESCRIPTION
In this PR, I have:

- Modified the list variables panel to set a subtotals dropdown with non-removed subtotals.
- Updated the list variables table model to set the first non-removed subtotal when choosing the invoice subtotal entity attribute. If there are no subtotals, the invoice type cannot be chosen.