### PR TITLE
BUG-4: Subtotal cannot be removed if it was associated to a removed variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2023-01-20
+
+### Fixed
+
+- Fixed an issue where a subtotal could not be removed if it was associated to a removed variable.
+
 ## [0.17.1] - 2023-01-20
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.1");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.2");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
+++ b/src/main/java/variable/persistence/mongo/MongoVariableRepository.java
@@ -189,8 +189,10 @@ public class MongoVariableRepository extends MongoRepository implements Variable
      */
     @Override
     public boolean existVariableWithSubtotal(int code) {
-        Bson subtotalFilter = Filters.eq("subtotal", code);
-        return super.count(subtotalFilter) > 0;
+        Bson subtotalWithGivenCode = Filters.eq("subtotal", code);
+        Bson nonDeletedVariable = Filters.eq("isDeleted", false);
+        Bson filters = Filters.and(subtotalWithGivenCode, nonDeletedVariable);
+        return super.count(filters) > 0;
     }
 
 }


### PR DESCRIPTION
In this PR, I have added a filter on the "MongoVariableRepository.existVariableWithSubtotal" method to only check non-removed variables when checking if the given subtotal is associated with any variable.