### PR TITLE
BUG-5: Variable with a removed subtotal can be restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] - 2023-01-21
+
+### Fixed
+
+- Fixed an issue where a variable with a removed subtotal could be restored.
+
 ## [0.17.2] - 2023-01-20
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.17.2</version>
+    <version>0.17.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.2");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.17.3");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
+++ b/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
@@ -76,6 +76,7 @@ public class SpanishDictionary extends Dictionary {
         super.setTranslation(LocalizationKey.INVOICE_TOTAL, "Total de la factura");
         super.setTranslation(LocalizationKey.VARIABLES, "Variables");
         super.setTranslation(LocalizationKey.SUBTOTAL_ASSOCIATED_WITH_VARIABLE_MESSAGE, "El subtotal no se puede eliminar porque está asociado a una variable");
+        super.setTranslation(LocalizationKey.VARIABLE_ASSOCIATED_WITH_DELETED_SUBTOTAL_MESSAGE, "La variable no puede ser restaurada porque está asociada a una variable eliminada");
     }
 
 }

--- a/src/main/java/shared/presentation/localization/LocalizationKey.java
+++ b/src/main/java/shared/presentation/localization/LocalizationKey.java
@@ -260,4 +260,9 @@ public enum LocalizationKey {
      * Message shown when the subtotal is associated to a variable.
      */
     SUBTOTAL_ASSOCIATED_WITH_VARIABLE_MESSAGE,
+    /**
+     * Message shown when the variable cannot be restored because the variable
+     * is associated with a deleted subtotal.
+     */
+    VARIABLE_ASSOCIATED_WITH_DELETED_SUBTOTAL_MESSAGE,
 }

--- a/src/main/java/variable/application/utils/VariableRestorationState.java
+++ b/src/main/java/variable/application/utils/VariableRestorationState.java
@@ -1,0 +1,25 @@
+package variable.application.utils;
+
+/**
+ * Represents all the states which the variable can be after trying to restore
+ * it.
+ */
+public enum VariableRestorationState {
+    /**
+     * The variable has been restored successfully.
+     */
+    RESTORED,
+    /**
+     * The variable cannot be restored because it is associated with a removed
+     * subtotal.
+     */
+    ASSOCIATED_WITH_DELETED_SUBTOTAL,
+    /**
+     * The variable cannot be restored because it has not been updated.
+     */
+    NOT_UPDATED,
+    /**
+     * The variable cannot be restored because it has not been found.
+     */
+    NOT_FOUND
+}


### PR DESCRIPTION
In this PR, I have:

- Modified the restore variable use case to check if the variable has an "invoice subtotal" entity attribute and is linked with a removed subtotal. In that case, we will not allow to restore that variable.
- Created an enum to indicate whether the variable has been restored or not and why.
- Added a message in the list variables panel to indicate that a variable cannot be restored because it is associated to a removed subtotal.