### PR TITLE
BUG-5: Variable with a removed subtotal can be restored [Fix]

### DIFF
--- a/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
+++ b/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
@@ -76,7 +76,7 @@ public class SpanishDictionary extends Dictionary {
         super.setTranslation(LocalizationKey.INVOICE_TOTAL, "Total de la factura");
         super.setTranslation(LocalizationKey.VARIABLES, "Variables");
         super.setTranslation(LocalizationKey.SUBTOTAL_ASSOCIATED_WITH_VARIABLE_MESSAGE, "El subtotal no se puede eliminar porque está asociado a una variable");
-        super.setTranslation(LocalizationKey.VARIABLE_ASSOCIATED_WITH_DELETED_SUBTOTAL_MESSAGE, "La variable no puede ser restaurada porque está asociada a una variable eliminada");
+        super.setTranslation(LocalizationKey.VARIABLE_ASSOCIATED_WITH_DELETED_SUBTOTAL_MESSAGE, "La variable no puede ser restaurada porque está asociada a una subtotal eliminado");
     }
 
 }

--- a/src/main/java/variable/application/usecases/RestoreVariable.java
+++ b/src/main/java/variable/application/usecases/RestoreVariable.java
@@ -1,5 +1,6 @@
 package variable.application.usecases;
 
+import subtotal.application.Subtotal;
 import variable.application.SubtotalVariable;
 import variable.application.Variable;
 import variable.application.utils.VariableRestorationState;
@@ -41,8 +42,9 @@ public class RestoreVariable {
 
         if (variable instanceof SubtotalVariable) {
             SubtotalVariable subtotalVariable = (SubtotalVariable) variable;
+            Subtotal subtotal = subtotalVariable.getSubtotal();
 
-            if (subtotalVariable.isDeleted()) {
+            if (subtotal.isDeleted()) {
                 return VariableRestorationState.ASSOCIATED_WITH_DELETED_SUBTOTAL;
             }
         }


### PR DESCRIPTION
In this PR, I fix an issue on BUG-5 when checking if the variable was associated to a removed subtotal, as I was taking the subtotal variable instead of the proper subtotal.