### PR TITLE
PS-9: Modify CHANGELOG for version 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added feature to edit a template.
+- Added feature to show a template.
 
 ## [0.23.0] - 2023-02-02
 


### PR DESCRIPTION
In this PR, I have modified the CHANGELOG for version 0.24.0 to indicate that we have added a feature on that version to show a template instead of editing.