### PR TITLE
BUG-6: Removed templates can be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2023-02-11
+
+### Fixed
+
+- Fixed an issue where removed variables could be edited.
+
 ## [0.27.0] - 2023-02-11
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.27.0</version>
+    <version>0.27.1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.27.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.27.1");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/shared/presentation/utils/ButtonRenderer.java
+++ b/src/main/java/shared/presentation/utils/ButtonRenderer.java
@@ -18,6 +18,16 @@ public class ButtonRenderer extends JButton implements TableCellRenderer {
     }
 
     /**
+     * Constructor.
+     *
+     * @param isEnabled Whether the button must be enabled or not.
+     */
+    public ButtonRenderer(boolean isEnabled) {
+        this.setOpaque(true);
+        this.setEnabled(isEnabled);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/template/presentation/panels/ShowTemplatePanel.java
+++ b/src/main/java/template/presentation/panels/ShowTemplatePanel.java
@@ -79,8 +79,16 @@ public class ShowTemplatePanel extends javax.swing.JPanel {
         Template template = this.showTemplate(templateCode);
 
         Map<String, String> templateFields = new HashMap<>();
+        boolean isDeleted = false;
 
         if (template != null) {
+            if (template.isDeleted()) {
+                isDeleted = true;
+                this.nameInput.setEditable(false);
+                this.chooseFileButton.setEnabled(false);
+                this.updateButton.setEnabled(false);
+            }
+
             this.codeInput.setText(Integer.toString(templateCode));
             this.nameInput.setText(template.getName());
             this.isDeletedCheckbox.setSelected(template.isDeleted());
@@ -99,7 +107,7 @@ public class ShowTemplatePanel extends javax.swing.JPanel {
             templateFields = template.getFields();
         }
 
-        this.templateFieldsPanel = new TemplateFieldsPanel(templateFields);
+        this.templateFieldsPanel = new TemplateFieldsPanel(templateFields, isDeleted);
         this.bookedPanel.setLayout(new GridLayout());
         this.bookedPanel.add(templateFieldsPanel);
     }

--- a/src/main/java/template/presentation/panels/TemplateFieldsPanel.java
+++ b/src/main/java/template/presentation/panels/TemplateFieldsPanel.java
@@ -30,7 +30,7 @@ public class TemplateFieldsPanel extends javax.swing.JPanel {
      */
     public TemplateFieldsPanel() {
         initComponents();
-        initializeTable();
+        initializeTable(false);
         initializeLabels();
     }
 
@@ -38,12 +38,17 @@ public class TemplateFieldsPanel extends javax.swing.JPanel {
      * Constructor.
      *
      * @param fields Map with all template fields data.
+     * @param isDeleted Whether the template is deleted or not.
      */
-    public TemplateFieldsPanel(Map<String, String> fields) {
+    public TemplateFieldsPanel(Map<String, String> fields, boolean isDeleted) {
         initComponents();
-        initializeTable();
+        initializeTable(isDeleted);
         initializeLabels();
         initializeTemplateFields(fields);
+
+        if (isDeleted) {
+            disableInputs();
+        }
     }
 
     /**
@@ -73,16 +78,18 @@ public class TemplateFieldsPanel extends javax.swing.JPanel {
 
     /**
      * Initialize the table.
+     *
+     * @param isDeleted Whether the template is deleted or not.
      */
-    private void initializeTable() {
+    private void initializeTable(boolean isDeleted) {
         Vector<String> columnNames = this.generateColumnNames();
 
-        table.setModel(new TemplateFieldsTableModel(new Vector<>(), columnNames));
-        table.addMouseListener(new TemplateFieldsMouseAdapter(table));
+        table.setModel(new TemplateFieldsTableModel(new Vector<>(), columnNames, isDeleted));
+        table.addMouseListener(new TemplateFieldsMouseAdapter(table, isDeleted));
 
         // Set a button renderer for the remove button.
         TableColumn removeColumn = table.getColumn(columnNames.get(2));
-        removeColumn.setCellRenderer(new ButtonRenderer());
+        removeColumn.setCellRenderer(new ButtonRenderer(!isDeleted));
     }
 
     /**
@@ -121,6 +128,13 @@ public class TemplateFieldsPanel extends javax.swing.JPanel {
 
             this.addTemplateField(templateFieldAttributes);
         }
+    }
+
+    /**
+     * Disable inputs.
+     */
+    private void disableInputs() {
+        this.addTemplateFieldButton.setEnabled(false);
     }
 
     /**

--- a/src/main/java/template/presentation/utils/TemplateFieldsMouseAdapter.java
+++ b/src/main/java/template/presentation/utils/TemplateFieldsMouseAdapter.java
@@ -13,6 +13,11 @@ import template.presentation.panels.TemplateFieldsPanel;
 public class TemplateFieldsMouseAdapter extends MouseAdapter {
 
     /**
+     * Whether the template is deleted or not.
+     */
+    private boolean isDeleted;
+
+    /**
      * Table associated to the mouse adapter.
      */
     private JTable table;
@@ -21,9 +26,11 @@ public class TemplateFieldsMouseAdapter extends MouseAdapter {
      * Constructor.
      *
      * @param table The table associated to the mouse adapter.
+     * @param isDeleted Whether the template is deleted or not.
      */
-    public TemplateFieldsMouseAdapter(JTable table) {
+    public TemplateFieldsMouseAdapter(JTable table, boolean isDeleted) {
         this.table = table;
+        this.isDeleted = isDeleted;
     }
 
     /**
@@ -32,6 +39,11 @@ public class TemplateFieldsMouseAdapter extends MouseAdapter {
      * @param evt The mouse event.
      */
     private void removeTemplateField(MouseEvent evt) {
+        // A template field can be only removed if the template is not deleted.
+        if (this.isDeleted) {
+            return;
+        }
+
         int row = table.rowAtPoint(evt.getPoint());
 
         DefaultTableModel tableModel = (DefaultTableModel) table.getModel();

--- a/src/main/java/template/presentation/utils/TemplateFieldsTableModel.java
+++ b/src/main/java/template/presentation/utils/TemplateFieldsTableModel.java
@@ -16,13 +16,20 @@ import template.application.usecases.EditTemplateField;
 public class TemplateFieldsTableModel extends DefaultTableModel {
 
     /**
+     * Whether the template is deleted or not.
+     */
+    private boolean isDeleted;
+
+    /**
      * Constructor.
      *
      * @param data Table data.
      * @param columnNames Table column names.
+     * @param isDeleted Whether the template is deleted or not.
      */
-    public TemplateFieldsTableModel(Vector<? extends Vector> data, Vector<?> columnNames) {
+    public TemplateFieldsTableModel(Vector<? extends Vector> data, Vector<?> columnNames, boolean isDeleted) {
         super(data, columnNames);
+        this.isDeleted = isDeleted;
     }
 
     /**
@@ -65,7 +72,8 @@ public class TemplateFieldsTableModel extends DefaultTableModel {
     @Override
     public boolean isCellEditable(int row, int column) {
         // All the columns except the remove button column can be edited.
-        return column < 2;
+        // Cells can be only edited if the template is not deleted.
+        return column < 2 && !this.isDeleted;
     }
 
     /**


### PR DESCRIPTION
In this PR, I have:

- Modified the button rendered to allow disabling the button cell if it is required.
- Modified the show template panel to disable all the inputs if the shown template is deleted.
- Modified the template fields panel to disable all the inputs if the associated template is deleted.
- Modified the template fields table model not to edit cells on the table, which contains the template fields data, when the associated template is deleted.
- Modified the template fields mouse adapter not to allow clicking on the "Remove" button for the corresponding template field if the associated template is deleted.