### PR TITLE
INVIT-2: Edit an invoice item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2023-02-16
+
+### Added
+
+- Added feature to edit an invoice item.
+
 ## [0.28.0] - 2023-02-16
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.28.0</version>
+    <version>0.29.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/invoice/application/usecases/EditInvoiceItem.java
+++ b/src/main/java/invoice/application/usecases/EditInvoiceItem.java
@@ -1,0 +1,31 @@
+package invoice.application.usecases;
+
+import invoice.application.InvoiceItemAttribute;
+import java.util.Map;
+import shared.application.utils.DescriptionValidator;
+
+/**
+ * Edit invoice item use case.
+ */
+public class EditInvoiceItem {
+
+    /**
+     * Constructor.
+     */
+    public EditInvoiceItem() {
+    }
+
+    /**
+     * Edit an invoice item based on the given attributes.
+     *
+     * @param attributes The invoice item attributes.
+     * @return Whether the invoice item has been edited or not.
+     */
+    public boolean execute(Map<InvoiceItemAttribute, Object> attributes) {
+        String description = (String) attributes.getOrDefault(InvoiceItemAttribute.DESCRIPTION, null);
+
+        // The invoice item can be edited if it has a valid description.
+        return DescriptionValidator.isValid(description);
+    }
+
+}

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.28.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.29.0");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
+++ b/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
@@ -99,6 +99,7 @@ public class SpanishDictionary extends Dictionary {
         super.setTranslation(LocalizationKey.ITEM, "Unidad");
         super.setTranslation(LocalizationKey.GENERATE, "Generar");
         super.setTranslation(LocalizationKey.INVOICE, "Factura");
+        super.setTranslation(LocalizationKey.INVALID_INVOICE_ITEM_DESCRIPTION_MESSAGE, "La descripción introducida para la unidad de la factura no es válida");
     }
 
 }

--- a/src/main/java/shared/presentation/localization/LocalizationKey.java
+++ b/src/main/java/shared/presentation/localization/LocalizationKey.java
@@ -353,4 +353,8 @@ public enum LocalizationKey {
      * Generate.
      */
     GENERATE,
+    /**
+     * Message shown when an invalid invoice item is introduced.
+     */
+    INVALID_INVOICE_ITEM_DESCRIPTION_MESSAGE,
 }


### PR DESCRIPTION
In this PR, I have:

- Added the edit invoice item use case.
- Updated the table model for the invoice items panel to edit an invoice item if a valid input is introduced for each field and mark all cells as editable except the remove button.