### PR TITLE
DNOTEIT-2: Edit a delivery note item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2023-05-01
+
+### Added
+
+- Added feature to edit a delivery note item.
+
 ## [0.43.0] - 2023-05-01
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.43.0</version>
+    <version>0.44.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/deliverynote/application/usecases/EditDeliveryNoteItem.java
+++ b/src/main/java/deliverynote/application/usecases/EditDeliveryNoteItem.java
@@ -1,0 +1,37 @@
+package deliverynote.application.usecases;
+
+import container.application.Container;
+import deliverynote.application.DeliveryNoteItemAttribute;
+import java.util.Map;
+import shared.application.utils.QtyValidator;
+
+/**
+ * Edit delivery note item use case.
+ */
+public class EditDeliveryNoteItem {
+
+    /**
+     * Constructor.
+     */
+    public EditDeliveryNoteItem() {
+    }
+
+    /**
+     * Edit a delivery note item based on the given attributes.
+     *
+     * @param attributes The delivery note item attributes.
+     * @return Whether the delivery note item can be edited or not.
+     */
+    public boolean execute(Map<DeliveryNoteItemAttribute, Object> attributes) {
+        int qty = (int) attributes.get(DeliveryNoteItemAttribute.QTY);
+
+        boolean isQtyValid = QtyValidator.isValid(qty);
+
+        if (!isQtyValid) {
+            return false;
+        }
+
+        Container container = (Container) attributes.get(DeliveryNoteItemAttribute.CONTAINER);
+        return container != null;
+    }
+}

--- a/src/main/java/deliverynote/presentation/panels/DeliveryNoteItemsPanel.java
+++ b/src/main/java/deliverynote/presentation/panels/DeliveryNoteItemsPanel.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Box;
 import javax.swing.ComboBoxModel;
+import javax.swing.DefaultCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -93,6 +94,11 @@ public class DeliveryNoteItemsPanel extends javax.swing.JPanel {
         Vector<String> columnNames = this.generateColumnNames();
 
         table.setModel(new DeliveryNoteItemsTableModel(new Vector<>(), columnNames));
+
+        // Set a combobox cell editor for the container column.
+        TableColumn containerColumn = table.getColumn(columnNames.get(0));
+        JComboBox comboBox = new JComboBox(new Vector<Container>(this.getContainers()));
+        containerColumn.setCellEditor(new DefaultCellEditor(comboBox));
 
         // Set a button renderer for the remove button.
         TableColumn removeColumn = table.getColumn(columnNames.get(2));

--- a/src/main/java/deliverynote/presentation/utils/DeliveryNoteItemsTableModel.java
+++ b/src/main/java/deliverynote/presentation/utils/DeliveryNoteItemsTableModel.java
@@ -1,7 +1,14 @@
 package deliverynote.presentation.utils;
 
+import deliverynote.application.DeliveryNoteItemAttribute;
+import deliverynote.application.usecases.EditDeliveryNoteItem;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
+import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
+import shared.presentation.localization.Localization;
+import shared.presentation.localization.LocalizationKey;
 
 /**
  * Table model for the delivery note items panel.
@@ -16,6 +23,26 @@ public class DeliveryNoteItemsTableModel extends DefaultTableModel {
      */
     public DeliveryNoteItemsTableModel(Vector<? extends Vector> data, Vector<?> columnNames) {
         super(data, columnNames);
+    }
+
+    /**
+     * Edit the delivery note item.
+     *
+     * @param newValue The new value for the modified cell.
+     * @param row The row of the modified cell.
+     * @param column The column of the modified cell.
+     * @return Whether the delivery note item is allowed to be edited or not.
+     */
+    private boolean editDeliveryNoteItem(Object newValue, int row, int column) {
+        Object container = column == 0 ? newValue : super.getValueAt(row, 0);
+        Object qty = column == 1 ? newValue : super.getValueAt(row, 1);
+
+        Map<DeliveryNoteItemAttribute, Object> attributes = new HashMap<>();
+        attributes.put(DeliveryNoteItemAttribute.CONTAINER, container);
+        attributes.put(DeliveryNoteItemAttribute.QTY, (int) qty);
+
+        EditDeliveryNoteItem editDeliveryNoteItem = new EditDeliveryNoteItem();
+        return editDeliveryNoteItem.execute(attributes);
     }
 
     /**
@@ -36,7 +63,28 @@ public class DeliveryNoteItemsTableModel extends DefaultTableModel {
      */
     @Override
     public boolean isCellEditable(int row, int column) {
-        return false;
+        // All the columns except the remove button column can be edited.
+        return column < 2;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object newValue, int row, int column) {
+        if (this.isCellEditable(row, column)) {
+            if (this.editDeliveryNoteItem(newValue, row, column)) {
+                super.setValueAt(newValue, row, column);
+            } else if (column == 0) {
+                // Invalid container, show message.
+                String invalidContainerMessage = Localization.getLocalization(LocalizationKey.INVALID_CONTAINER_MESSAGE);
+                JOptionPane.showMessageDialog(null, invalidContainerMessage);
+            } else if (column == 1) {
+                // Invalid quantity, show message.
+                String invalidQtyMessage = Localization.getLocalization(LocalizationKey.INVALID_QTY_MESSAGE);
+                JOptionPane.showMessageDialog(null, invalidQtyMessage);
+            }
+        }
     }
 
 }

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.43.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.44.0");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 

--- a/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
+++ b/src/main/java/shared/presentation/dictionary/languages/SpanishDictionary.java
@@ -112,6 +112,8 @@ public class SpanishDictionary extends Dictionary {
         super.setTranslation(LocalizationKey.CONTAINER, "Palé/Caja");
         super.setTranslation(LocalizationKey.INVALID_DELIVERY_NOTE_ITEM_MESSAGE, "Elemento no añadido porque no es válido");
         super.setTranslation(LocalizationKey.DELIVERY_NOTE, "Albarán");
+        super.setTranslation(LocalizationKey.INVALID_CONTAINER_MESSAGE, "El contenedor introducido es inválido");
+        super.setTranslation(LocalizationKey.INVALID_QTY_MESSAGE, "La cantidad introducida es inválida");
     }
 
 }

--- a/src/main/java/shared/presentation/localization/LocalizationKey.java
+++ b/src/main/java/shared/presentation/localization/LocalizationKey.java
@@ -405,4 +405,13 @@ public enum LocalizationKey {
      * Delivery note.
      */
     DELIVERY_NOTE,
+    /**
+     * Message shown when the introduced container is invalid.
+     */
+    INVALID_CONTAINER_MESSAGE,
+    /**
+     * Message shown when the introduced quantity is invalid.
+     */
+    INVALID_QTY_MESSAGE,
+
 }


### PR DESCRIPTION
In this PR, I have:

- Established the use case to edit a delivery note item.
- Modified the delivery note items panel to set a combobox cell editor for the container column. So, we display a selector when editing a container.
- Edited the delivery note items table model for the container and quantity edition.
- 