### PR TITLE
DNOTEIT-3: Remove a delivery note item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.44.0] - 2023-05-01
+## [0.45.0] - 2023-05-07
+
+### Added
+
+- Added feature to remove a delivery note item.
+
+## [0.44.0] - 2023-05-07
 
 ### Added
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fgen</groupId>
     <artifactId>fgen</artifactId>
-    <version>0.44.0</version>
+    <version>0.45.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/deliverynote/presentation/panels/DeliveryNoteItemsPanel.java
+++ b/src/main/java/deliverynote/presentation/panels/DeliveryNoteItemsPanel.java
@@ -6,6 +6,7 @@ import container.persistence.mongo.MongoContainerRepository;
 import deliverynote.application.DeliveryNoteItem;
 import deliverynote.application.DeliveryNoteItemAttribute;
 import deliverynote.application.usecases.CreateDeliveryNoteItem;
+import deliverynote.presentation.utils.DeliveryNoteItemsMouseAdapter;
 import deliverynote.presentation.utils.DeliveryNoteItemsTableModel;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -94,6 +95,7 @@ public class DeliveryNoteItemsPanel extends javax.swing.JPanel {
         Vector<String> columnNames = this.generateColumnNames();
 
         table.setModel(new DeliveryNoteItemsTableModel(new Vector<>(), columnNames));
+        table.addMouseListener(new DeliveryNoteItemsMouseAdapter(table));
 
         // Set a combobox cell editor for the container column.
         TableColumn containerColumn = table.getColumn(columnNames.get(0));

--- a/src/main/java/deliverynote/presentation/utils/DeliveryNoteItemsMouseAdapter.java
+++ b/src/main/java/deliverynote/presentation/utils/DeliveryNoteItemsMouseAdapter.java
@@ -1,0 +1,54 @@
+package deliverynote.presentation.utils;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+
+/**
+ * Mouse adapter for the delivery note items panel, which includes a button to
+ * remove a delivery note item.
+ */
+public class DeliveryNoteItemsMouseAdapter extends MouseAdapter {
+
+    /**
+     * Table associated to the mouse adapter.
+     */
+    private JTable table;
+
+    /**
+     * Constructor.
+     *
+     * @param table The table associated to the mouse adapter.
+     */
+    public DeliveryNoteItemsMouseAdapter(JTable table) {
+        this.table = table;
+    }
+
+    /**
+     * Remove the delivery note item.
+     *
+     * @param evt The mouse event.
+     */
+    private void removeDeliveryNoteItem(MouseEvent evt) {
+        int row = table.rowAtPoint(evt.getPoint());
+
+        DefaultTableModel tableModel = (DefaultTableModel) table.getModel();
+        tableModel.removeRow(row);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void mouseClicked(MouseEvent evt) {
+        int column = table.columnAtPoint(evt.getPoint());
+
+        if (column == 2) {
+            // In column 2, there is a button to remove the chosen delivery note
+            // item defined by the clicked row.
+            this.removeDeliveryNoteItem(evt);
+        }
+    }
+
+}

--- a/src/main/java/shared/presentation/Main.java
+++ b/src/main/java/shared/presentation/Main.java
@@ -37,7 +37,7 @@ public class Main {
         MongoDatabaseConnection.setInstance(dbUsername, dbPassword, dbHost, dbName);
 
         // Indicate application details.
-        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.44.0");
+        ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.VERSION, "0.45.0");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.NAME, "FGEN");
         ApplicationConfiguration.addConfigurationVariable(ConfigurationVariable.PROJECT_URL, "https://github.com/albertosml/fgen");
 


### PR DESCRIPTION
In this PR, I have added a mouse adapter for the delivery note items table to remove the item by clicking on the corresponding delivery note item row.